### PR TITLE
fix(public): use url('/privacy'|'/terms') instead of non-existent named routes

### DIFF
--- a/resources/views/partials/footer-nav.blade.php
+++ b/resources/views/partials/footer-nav.blade.php
@@ -2,8 +2,8 @@
 <footer class="container py-4 text-center small">
   <a href="{{ route('about') }}">{{ __('About') }}</a> ·
   <a href="{{ route('faq') }}">{{ __('FAQ') }}</a> ·
-  <a href="{{ route('privacy') }}">{{ __('Privacy') }}</a> ·
-  <a href="{{ route('terms') }}">{{ __('Terms') }}</a> ·
+  <a href="{{ url('/privacy') }}">{{ __('Privacy') }}</a> ·
+  <a href="{{ url('/terms') }}">{{ __('Terms') }}</a> ·
   <a href="{{ route('contact.show') }}">{{ __('Contact') }}</a>
 </footer>
 @endif {{-- ORG_AUTH_GUARD --}}

--- a/resources/views/partials/footer-public.blade.php
+++ b/resources/views/partials/footer-public.blade.php
@@ -1,7 +1,7 @@
 <footer class="mt-5 py-4" style="background:#0b1324;color:#fff">
   <div class="container small d-flex gap-3">
     <span>© {{ date('Y') }} SwaedUAE</span>
-    <a class="link-light" href="{{ route('privacy') }}">Privacy</a>
-    <a class="link-light" href="{{ route('terms') }}">Terms</a>
+    <a class="link-light" href="{{ url('/privacy') }}">Privacy</a>
+    <a class="link-light" href="{{ url('/terms') }}">Terms</a>
   </div>
 </footer>


### PR DESCRIPTION
Removes leftover route('privacy'|'terms') calls in shared layouts/partials to stop 500s on / and /about. No Vite, TravelPro only.