### PR TITLE
feat(admin): add QR verify page

### DIFF
--- a/app/Http/Controllers/Admin/QrVerifyController.php
+++ b/app/Http/Controllers/Admin/QrVerifyController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Certificate;
+use Illuminate\Http\Request;
+
+class QrVerifyController extends Controller
+{
+    public function index(Request $request)
+    {
+        $code = trim((string) $request->query('code', ''));
+        $status = null;
+        $certificate = null;
+
+        if ($code !== '') {
+            $certificate = Certificate::where('code', $code)->first();
+            if ($certificate) {
+                $status = $certificate->revoked_at ? 'expired' : 'valid';
+            } else {
+                $status = 'invalid';
+            }
+        }
+
+        return view('admin.qr.verify', [
+            'code' => $code,
+            'status' => $status,
+            'certificate' => $certificate,
+        ]);
+    }
+}

--- a/resources/views/admin/qr/verify.blade.php
+++ b/resources/views/admin/qr/verify.blade.php
@@ -1,0 +1,34 @@
+@extends('layouts.admin')
+@section('title','QR Verify')
+
+@section('content')
+<div class="container py-4">
+    <h1 class="h3 mb-3">QR Verify</h1>
+    <form method="GET" class="mb-4">
+        <div class="input-group">
+            <input type="text" name="code" value="{{ $code }}" class="form-control" placeholder="Code">
+            <button class="btn btn-primary" type="submit">Search</button>
+        </div>
+    </form>
+
+    @if($status)
+    <div class="card">
+        <div class="card-body">
+            @if($status === 'valid')
+                <div class="alert alert-success mb-3">Valid certificate</div>
+            @elseif($status === 'expired')
+                <div class="alert alert-warning mb-3">Certificate revoked</div>
+            @else
+                <div class="alert alert-danger mb-3">Code not found</div>
+            @endif
+            @if($certificate)
+                <p class="mb-1"><strong>{{ $certificate->code }}</strong></p>
+                <p class="mb-3">{{ $certificate->hours }} {{ __('hours') }}</p>
+                <a href="{{ route('qr.verify', $certificate->code) }}" class="btn btn-outline-secondary btn-sm" target="_blank">Public verify</a>
+            @endif
+        </div>
+    </div>
+    @endif
+</div>
+@endsection
+

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\OpportunityController;
+use App\Http\Controllers\Admin\QrVerifyController;
 use App\Http\Controllers\Admin\UserController;
 use Illuminate\Support\Facades\Route;
 
@@ -32,6 +33,7 @@ Route::domain(env('ADMIN_DOMAIN', 'admin.swaeduae.ae'))
         Route::get('/certificates', [\App\Http\Controllers\Admin\CertificateController::class, 'index'])->name('certificates.index');
         Route::get('/attendance', [\App\Http\Controllers\Admin\AttendanceAdminController::class, 'index'])->name('attendance.index');
         Route::get('/applicants', [\App\Http\Controllers\Admin\ApplicantsController::class, 'index'])->name('applicants.index');
+        Route::get('/qr/verify', [QrVerifyController::class, 'index'])->name('qr.verify');
         Route::get('/', [DashboardController::class, 'index'])->name('dashboard');
 
         Route::resource('users', UserController::class)->only(['index', 'show', 'update', 'destroy']);

--- a/tests/Feature/Admin/QrVerifyTest.php
+++ b/tests/Feature/Admin/QrVerifyTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Certificate;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class QrVerifyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminUser(): User
+    {
+        return User::factory()->create(['role' => 'admin']);
+    }
+
+    public function test_valid_code_shows_certificate(): void
+    {
+        $admin = $this->adminUser();
+        Certificate::create([
+            'uuid' => Str::uuid(),
+            'code' => 'VALID123',
+            'signature' => 'sig',
+            'hours' => 2,
+            'issued_at' => now(),
+        ]);
+
+        $this->actingAs($admin)
+            ->get('/admin/qr/verify?code=VALID123')
+            ->assertStatus(200)
+            ->assertSee('Valid certificate');
+    }
+
+    public function test_invalid_code_shows_error(): void
+    {
+        $admin = $this->adminUser();
+
+        $this->actingAs($admin)
+            ->get('/admin/qr/verify?code=NOPE')
+            ->assertStatus(200)
+            ->assertSee('Code not found');
+    }
+
+    public function test_expired_code_shows_warning(): void
+    {
+        $admin = $this->adminUser();
+        Certificate::create([
+            'uuid' => Str::uuid(),
+            'code' => 'OLD123',
+            'signature' => 'sig',
+            'hours' => 1,
+            'issued_at' => now()->subDay(),
+            'revoked_at' => now(),
+        ]);
+
+        $this->actingAs($admin)
+            ->get('/admin/qr/verify?code=OLD123')
+            ->assertStatus(200)
+            ->assertSee('Certificate revoked');
+    }
+}


### PR DESCRIPTION
## Summary
- add admin QR verify controller, view, and route
- cover valid/invalid/expired codes in tests

## Testing
- `./vendor/bin/pest --filter QrVerifyTest` *(fails: no such table: cache)*
- `./_tools/agent_check.sh` *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68bc95e700508320accf22f00305bbd2