### PR TITLE
PR #30 — Deploy hygiene: always use shared `.env`

### DIFF
--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -5,6 +5,17 @@
 Releases live under `releases/` with a shared `.env` outside each release. A `current` symlink points to the active release.
 Deploys use `/usr/local/bin/swaed_deploy_pr.sh <PR#>` for pull requests or `/usr/local/bin/swaed_deploy_pr.sh main` for the main branch to fetch the release, install dependencies, and swap the symlink.
 
+### Deploy
+
+After the `current` symlink is updated, link in the shared environment and rebuild the configuration cache:
+
+```bash
+ln -sf /var/www/swaeduae/shared/.env /var/www/swaeduae/current/.env
+cd /var/www/swaeduae/current && php artisan config:clear && php artisan config:cache
+```
+
+The `.env` resides in `shared` so all releases use identical settings. Refreshing the config cache ensures Laravel picks up those values instead of falling back to framework defaults.
+
 ## Environment
 
 - `APP_DEBUG=false`

--- a/tools/full_health.sh
+++ b/tools/full_health.sh
@@ -16,6 +16,9 @@ hit(){ curl -s -o /dev/null -w "%{http_code}" "$1"; }
   phpc config:cache >/dev/null || true; phpc route:cache >/dev/null || true; phpc view:cache >/dev/null || true
   echo "caches: refreshed"
 
+  echo; echo "== CONFIG SNAPSHOT =="
+  php -r 'require "vendor/autoload.php"; $app=require "bootstrap/app.php"; $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap(); echo "Queue: ".config("queue.default").PHP_EOL; echo "DB:    ".config("database.default").PHP_EOL; echo "Log:   ".config("logging.default").PHP_EOL;'
+
   echo; echo "== ABOUT =="; phpc about
 
   echo; echo "== ROUTES (top) =="; phpc route:list | sed -n '1,80p'

--- a/tools/swaed_deploy_pr.sh
+++ b/tools/swaed_deploy_pr.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Link shared .env and rebuild config cache
+ln -sf /var/www/swaeduae/shared/.env /var/www/swaeduae/current/.env
+cd /var/www/swaeduae/current && php artisan config:clear && php artisan config:cache
+ENV_LINKED=$(readlink -f /var/www/swaeduae/current/.env)
+echo "ENV_LINKED=$ENV_LINKED"


### PR DESCRIPTION
## Summary
- document using a shared `.env` and recaching config after switching `current`
- expose Queue/DB/Log values in full health script
- template deploy script links shared `.env` and rebuilds config cache

## Testing
- `bash tools/full_health.sh` *(fails: require vendor/autoload.php)*
- `phpunit` *(fails: command not found)*
- `bash tools/swaed_deploy_pr.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bca80fb7ac8320927696f4f33ba59d