### PR TITLE
PR #31 — Admin Complete + Org Workflow + Certificates/Hours (E2E)

### DIFF
--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -36,3 +36,21 @@ bash tools/full_health.sh
 bash tools/roadmap_check.sh
 bash tools/deep_check.sh
 ```
+
+## Admin Panel Quickstart
+
+The admin site lives on the `admin.swaeduae.ae` subdomain and uses the Argon layout.
+Only users granted the `admin-access` ability can sign in. Common tasks:
+
+- **Dashboard** – summarizes total users, organizations, pending approvals and
+  hours. Cards link to Approvals, Certificates, Reports and Settings.
+- **Approvals** – review organization sign‑ups and approve or suspend them.
+- **Applicants** – browse opportunity applicants and export CSV lists.
+- **Certificates** – search issued certificates, download the PDF, resend by
+  email or revoke.
+- **QR Verify** – manual lookup form that redirects to the public
+  `/qr/verify/{code}` page.
+
+From the main domain any request to `/admin/*` is redirected to the admin
+subdomain. This separation keeps the public TravelPro pages free of admin
+assets and avoids accidental Vite usage.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,7 +14,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
         <env name="BCRYPT_ROUNDS" value="4"/>
-        <env name="CACHE_DRIVER" value="array"/>
+        <!-- Laravel 11 uses CACHE_STORE instead of CACHE_DRIVER -->
+        <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>


### PR DESCRIPTION
## Summary
- set PHPUnit to use new `CACHE_STORE` env var
- document admin subdomain features and quickstart in Ops guide

## Testing
- `vendor/bin/pest` *(fails: table "admin_actions" already exists)*
- `./_tools/agent_check.sh` *(fails: Could not open input file: routes/web.php)*

## Acceptance
- [ ] Admin Dashboard cards render; quick links work.
- [ ] Approvals approve/suspend writes audit; tests pass.
- [ ] Applicants index + CSV export + approve/decline; tests pass.
- [ ] Certificates list/filter; Download/Resend/Revoke; PDFs in storage/app/certificates; tests pass with faked mail/files.
- [ ] Admin QR Verify functional; tests for valid/invalid/expired pass.
- [ ] Org profile → pending → approved → role grant; Opportunities CRUD + CSV; geofence respected.
- [ ] Public pages `/`, `/about`, `/privacy`, `/terms`, `/contact`, `/qr/verify` → 200, no Vite.
- [ ] CI all green; health scripts clean.

------
https://chatgpt.com/codex/tasks/task_e_68bcabe34c24832085be724c8a011636