### PR TITLE
Harden API heartbeat route

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -33,8 +33,6 @@ Route::prefix('v1')->group(function () {
         ]);
     });
 
-    Route::middleware(['auth:sanctum','throttle:ping'])
-        ->name('attendance.heartbeat');
 });
 
 // Include agent ping health route if present
@@ -50,8 +48,13 @@ Route::get('/agent/ping', function (\Illuminate\Http\Request $r) {
 
 if (file_exists(base_path('routes/_agent_diag_api.php'))) require base_path('routes/_agent_diag_api.php');
 
-// --- Swaed: Volunteer heartbeat (Sanctum) ---
-Route::middleware('auth:sanctum')->post(
-    'v1/attendance/heartbeat',
-    [\App\Http\Controllers\Api\AttendanceHeartbeatController::class, 'store']
-)->name('attendance.heartbeat');
+Route::middleware(['auth:sanctum','throttle:api'])
+    ->withoutMiddleware([
+        \App\Http\Middleware\EnforceOrgRegistration::class,
+        \App\Http\Middleware\MicroCache::class,
+        \App\Http\Middleware\SetLocaleAndHeaders::class,
+        \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
+        \Illuminate\Session\Middleware\StartSession::class,
+    ])
+    ->post('/v1/attendance/heartbeat', [AttendanceHeartbeatController::class, 'store'])
+    ->name('api.attendance.heartbeat');


### PR DESCRIPTION
## Summary
- lock API heartbeat to api.php and drop web middleware

## Testing
- `composer install --no-interaction` *(fails: Please provide a valid cache path -> resolved by creating storage & cache directories)*
- `vendor/bin/phpunit tests/Feature/Attendance/HeartbeatTest.php` *(fails: no such table: information_schema.STATISTICS)*
- `./_tools/agent_check.sh` *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd3ef56d48320a3a20b08585b5080