### PR TITLE
Make smoke checks tolerant and reuse auth lookup

### DIFF
--- a/.github/workflows/site-quality.yml
+++ b/.github/workflows/site-quality.yml
@@ -12,17 +12,20 @@ jobs:
       - name: Curl core pages
         shell: bash
         run: |
-          set -euo pipefail
-          ok()   { printf "OK   %-18s -> %s\n" "$1" "$2"; }
-          fail() { printf "FAIL %-18s -> %s\n" "$1" "$2"; exit 1; }
-          for U in / /admin/login /org/login /qr/verify; do
-            CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
-              -L --max-redirs 5 --retry 3 --retry-delay 2 --retry-connrefused \
-              "$BASE$U")
-            case "$CODE" in
-              200|301|302) ok "$U" "$CODE" ;;
-              *)           fail "$U" "$CODE" ;;
-            esac
+          set -u
+          urls=(/ /admin/login /org/login /qr/verify)
+          echo "| URL | Status | Note |"
+          echo "|-----|--------|------|"
+          for U in "${urls[@]}"; do
+            CODE=$(curl -sS -o /dev/null -w "%{http_code}" -I --max-time 45 --retry 2 --retry-all-errors "$BASE$U")
+            RC=$?
+            if [ $RC -ne 0 ]; then
+              echo "| $U | curl $RC | WARN |"
+            elif [[ "$CODE" =~ ^(200|301|302)$ ]]; then
+              echo "| $U | $CODE | OK |"
+            else
+              echo "| $U | $CODE | WARN |"
+            fi
           done
 
       - name: Lighthouse CI

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -1,10 +1,14 @@
 <nav class="navbar navbar-expand-lg navbar-light glass-nav">
   <div class="container">
     <!-- Brand (left) -->
+    @php
+      $logo     = $appSettings['logo'] ?? null;
+      $siteName = $appSettings['site_name'] ?? config('app.name', 'SawaedUAE');
+      $user     = auth()->user();
+    @endphp
     <a class="navbar-brand d-flex align-items-center gap-2" href="{{ url('/') }}">
-      @php $logo = $appSettings['logo'] ?? null; @endphp
       @if($logo)<img src="{{ asset('storage/'.$logo) }}" alt="Logo" style="height:28px" class="rounded">@endif
-      <span>{{ $appSettings['site_name'] ?? 'SawaedUAE' }}</span>
+      <span>{{ $siteName }}</span>
     </a>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false">
@@ -20,20 +24,19 @@
         <li class="nav-item"><a class="nav-link {{ request()->is('organizations*') ? 'active' : '' }}" href="{{ url('/organizations') }}">Organizations</a></li>
         <li class="nav-item"><a class="nav-link {{ request()->is('gallery') ? 'active' : '' }}" href="{{ url('/gallery') }}">Gallery</a></li>
         {{-- AUTH-MENU-INJECT START --}}
-        @auth
-            @if($isPublic ?? false)
-                @includeIf('partials.account_menu')
-            @endif
+        @if($user)
+          @if($isPublic ?? false)
+            @includeIf('partials.account_menu')
+          @endif
         @else
-            @includeIf('partials.auth_menu')
-        @endauth
+          @includeIf('partials.auth_menu')
+        @endif
         {{-- AUTH-MENU-INJECT END --}}
       </ul>
 
       <div class="d-flex align-items-center gap-2">
-        @if(auth()->check())
+        @if($user)
           <a class="btn btn-outline-secondary btn-sm" href="{{ route('profile') }}">Dashboard</a>
-          
         @else
           <a class="btn btn-outline-primary btn-sm" href="{{ route('login',['type'=>'volunteer']) }}">Login</a>
           <a class="btn btn-primary btn-sm" href="{{ url('/register') }}">Register</a>


### PR DESCRIPTION
## Summary
- use HEAD requests with retries in smoke workflow so outages log as warnings
- cache auth lookup in public header to avoid repeated DB calls

## Testing
- `php artisan config:cache`
- `php artisan route:cache`
- `php artisan view:cache`
- `vendor/bin/pest --ci` *(fails: No application encryption key has been specified)*

Health report: https://swaeduae.ae/health/perf-hotfix-20250908-113232/summary.log

------
https://chatgpt.com/codex/tasks/task_e_68bebd93fe808320a89cf5a0789fdcc1