### PR TITLE
Admin: Approvals (pending orgs → approve/decline)

### DIFF
--- a/resources/views/admin/approvals/index.blade.php
+++ b/resources/views/admin/approvals/index.blade.php
@@ -1,66 +1,46 @@
-@extends('admin.layout')
+@extends('layouts.admin')
+@section('title','Approvals')
 @section('content')
-<div class="container-fluid py-3">
-  <div class="d-flex align-items-center justify-content-between mb-3">
-    <h4 class="mb-0">Approvals</h4>
-    <form class="d-flex gap-2" method="get" action="{{ route('admin.approvals.index') }}">
-      @php($t = request('type','all')); @php($s = request('status','pending'))
-      <select name="type" class="form-select form-select-sm" onchange="this.form.submit()">
-        <option value="all"  {{ $t==='all'?'selected':'' }}>All</option>
-        <option value="orgs" {{ $t==='orgs'?'selected':'' }}>Organizations</option>
-        <option value="apps" {{ $t==='apps'?'selected':'' }}>Applications</option>
-      </select>
-      <select name="status" class="form-select form-select-sm" onchange="this.form.submit()">
-        @foreach(['pending','approved','denied'] as $opt)
-          <option value="{{ $opt }}" {{ $s===$opt?'selected':'' }}>{{ ucfirst($opt) }}</option>
-        @endforeach
-      </select>
-    </form>
+@if(session('status'))
+  <div class="alert alert-success">{{ session('status') }}</div>
+@endif
+@if($errors->any())
+  <div class="alert alert-danger">{{ $errors->first() }}</div>
+@endif
+<div class="card">
+  <div class="card-header">Pending Organizations</div>
+  <div class="table-responsive">
+    <table class="table mb-0">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Created</th>
+          <th class="text-end">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        @forelse($orgs as $org)
+        <tr>
+          <td>{{ $org->org_name }}</td>
+          <td>{{ $org->user->email ?? '' }}</td>
+          <td>{{ $org->created_at?->format('Y-m-d') }}</td>
+          <td class="text-end">
+            <form action="{{ route('admin.approvals.orgs.approve', $org->id) }}" method="post" class="d-inline">
+              @csrf
+              <button class="btn btn-success btn-sm">Approve</button>
+            </form>
+            <form action="{{ route('admin.approvals.orgs.decline', $org->id) }}" method="post" class="d-inline">
+              @csrf
+              <button class="btn btn-danger btn-sm">Decline</button>
+            </form>
+          </td>
+        </tr>
+        @empty
+        <tr><td colspan="4" class="text-center text-muted">No pending organizations.</td></tr>
+        @endforelse
+      </tbody>
+    </table>
   </div>
-
-  @foreach([['orgs',$orgs,'Organizations'],['apps',$apps,'Volunteer Applications']] as [$key,$rows,$title])
-    @if($type==='all' || $type===$key)
-    <div class="card mb-4">
-      <div class="card-header"><strong>{{ $title }}</strong></div>
-      <div class="table-responsive">
-        <table class="table table-sm mb-0">
-          <thead><tr><th>ID</th><th>A</th><th>B</th><th>Status</th><th>Created</th><th>Actions</th></tr></thead>
-          <tbody>
-          @forelse($rows as $r)
-            <tr>
-              <td>{{ $r->id }}</td>
-              <td>{{ $r->org_name ?? $r->user_id ?? '-' }}</td>
-              <td>{{ $r->org_code ?? $r->opportunity_id ?? '-' }}</td>
-              <td><span class="badge bg-secondary">{{ $r->status }}</span></td>
-              <td>{{ \Carbon\Carbon::parse($r->created_at)->diffForHumans() }}</td>
-              <td class="d-flex gap-2">
-                @if($key==='orgs')
-                  <form method="post" action="{{ route('admin.approvals.orgs.approve',$r->id) }}">@csrf
-                    <button class="btn btn-success btn-sm">Approve</button>
-                  </form>
-                  <form method="post" action="{{ route('admin.approvals.orgs.deny',$r->id) }}" class="d-flex gap-1">@csrf
-                    <input name="reason" class="form-control form-control-sm" placeholder="Reason" />
-                    <button class="btn btn-danger btn-sm">Deny</button>
-                  </form>
-                @else
-                  <form method="post" action="{{ route('admin.approvals.apps.approve',$r->id) }}">@csrf
-                    <button class="btn btn-success btn-sm">Approve</button>
-                  </form>
-                  <form method="post" action="{{ route('admin.approvals.apps.deny',$r->id) }}" class="d-flex gap-1">@csrf
-                    <input name="reason" class="form-control form-control-sm" placeholder="Reason" />
-                    <button class="btn btn-danger btn-sm">Deny</button>
-                  </form>
-                @endif
-              </td>
-            </tr>
-          @empty
-            <tr><td colspan="6" class="text-muted">No records.</td></tr>
-          @endforelse
-          </tbody>
-        </table>
-      </div>
-    </div>
-    @endif
-  @endforeach
 </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Auth\SimplePasswordResetController;
 use App\Http\Controllers\CertificateController;
 use App\Http\Controllers\CertificatePdfController;
 use App\Http\Controllers\ContactController;
+use App\Http\Controllers\Admin\ApprovalsController;
 use App\Http\Controllers\My\ProfileController;
 use App\Http\Controllers\QR\VerifyController;
 use Illuminate\Support\Facades\Route;
@@ -49,6 +50,12 @@ Route::get('/qr/verify/{serial?}', [VerifyController::class, 'show'])->name('qr.
 
 // Admin login alias → /login
 Route::get('/admin/login', fn () => redirect()->to('/login'))->name('admin.login');
+
+Route::middleware(['web','auth','can:admin-access'])->prefix('admin')->name('admin.')->group(function(){
+    Route::get('/approvals',[ApprovalsController::class,'index'])->name('approvals.index');
+    Route::post('/approvals/orgs/{id}/approve',[ApprovalsController::class,'approveOrg'])->whereNumber('id')->name('approvals.orgs.approve');
+    Route::post('/approvals/orgs/{id}/decline',[ApprovalsController::class,'declineOrg'])->whereNumber('id')->name('approvals.orgs.decline');
+});
 
 // Guest auth
 Route::middleware(['web', 'guest', 'throttle:10,1'])->group(function () {

--- a/tests/Feature/Admin/ApprovalsTest.php
+++ b/tests/Feature/Admin/ApprovalsTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\OrgProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class ApprovalsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Role::create(['name' => 'admin']);
+        Role::create(['name' => 'org']);
+    }
+
+    public function test_admin_can_approve_org_profile(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $orgUser = User::factory()->create();
+        $profile = OrgProfile::create([
+            'user_id' => $orgUser->id,
+            'org_name' => 'Org',
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($admin)
+            ->from('/admin/approvals')
+            ->post(route('admin.approvals.orgs.approve', $profile->id));
+
+        $response->assertRedirect('/admin/approvals');
+        $response->assertSessionHas('status');
+
+        $this->assertDatabaseHas('org_profiles', [
+            'id' => $profile->id,
+            'status' => 'approved',
+        ]);
+        $this->assertTrue($orgUser->fresh()->hasRole('org'));
+    }
+
+    public function test_admin_can_decline_org_profile(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $orgUser = User::factory()->create();
+        $profile = OrgProfile::create([
+            'user_id' => $orgUser->id,
+            'org_name' => 'Org',
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($admin)
+            ->from('/admin/approvals')
+            ->post(route('admin.approvals.orgs.decline', $profile->id));
+
+        $response->assertRedirect('/admin/approvals');
+        $this->assertDatabaseHas('org_profiles', [
+            'id' => $profile->id,
+            'status' => 'rejected',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add admin approvals routes under /admin/approvals
- implement ApprovalsController to approve/decline org profiles and manage org role
- add minimal Blade view listing pending organizations with actions
- cover approve/decline flow with feature tests

## Testing
- `composer install --no-interaction` *(fails: Could not open input file: artisan)*
- `./vendor/bin/phpunit tests/Feature/Admin/ApprovalsTest.php` *(fails: no such table: information_schema.STATISTICS)*

------
https://chatgpt.com/codex/tasks/task_e_68bed8d30b308320926ebe7318c27777